### PR TITLE
[FIX] 카카오 로그인 API 연결 로직 수정

### DIFF
--- a/Projects/Core/Models/Model/Auth/SocialLogin.swift
+++ b/Projects/Core/Models/Model/Auth/SocialLogin.swift
@@ -9,15 +9,17 @@
 import Foundation
 
 public struct SocialLogin: Equatable {
-  public let id: String?
-  public let authorization: String
-  public var identityToken: String?
+  public let idToken: String
+  public let nonce: String?
   public let provider: Socialtype
   
-  public init(id: String? = nil, authorization: String, identityToken: String? = nil, provider: Socialtype) {
-    self.id = id
-    self.authorization = authorization
-    self.identityToken = identityToken
+  public init(
+    idToken: String,
+    nonce: String? = nil,
+    provider: Socialtype
+  ) {
+    self.idToken = idToken
+    self.nonce = nonce
     self.provider = provider
   }
 }

--- a/Projects/Core/Services/SocialLogin/AppleLogin.swift
+++ b/Projects/Core/Services/SocialLogin/AppleLogin.swift
@@ -41,9 +41,9 @@ final class AppleLogin: NSObject, ASAuthorizationControllerDelegate {
     switch authorization.credential {
     case let appleIDCredential as ASAuthorizationAppleIDCredential:
       let email = appleIDCredential.email
-      print("appleLogin email \(email ?? "")")
+      debugPrint("appleLogin email \(email ?? "")")
       let fullName = appleIDCredential.fullName
-      print("appleLogin fullName \(fullName?.description ?? "")")
+      debugPrint("appleLogin fullName \(fullName?.description ?? "")")
       
       guard let tokenData = appleIDCredential.identityToken,
             let token = String(data: tokenData, encoding: .utf8) else {
@@ -52,7 +52,7 @@ final class AppleLogin: NSObject, ASAuthorizationControllerDelegate {
         return
       }
       
-      print("appleLogin token \(token)")
+      debugPrint("appleLogin token \(token)")
       
       guard let authorizationCode = appleIDCredential.authorizationCode,
             let authorizationCodeString = String(data: authorizationCode, encoding: .utf8) else {
@@ -61,12 +61,12 @@ final class AppleLogin: NSObject, ASAuthorizationControllerDelegate {
           return
       }
       
-      print("appleLogin authorizationCode \(authorizationCodeString)")
+      debugPrint("appleLogin authorizationCode \(authorizationCodeString)")
       
       let userIdentifier = appleIDCredential.user
-      print("appleLogin authenticated user: \(userIdentifier)")
+      debugPrint("appleLogin authenticated user: \(userIdentifier)")
       
-      let info = SocialLogin(id: userIdentifier, authorization: authorizationCodeString, identityToken: token, provider: .apple)
+      let info = SocialLogin(idToken: token, provider: .apple)
         
       continuation?.resume(returning: info)
       continuation = nil

--- a/Projects/Features/Scene/Auth/Login/LoginFeature.swift
+++ b/Projects/Features/Scene/Auth/Login/LoginFeature.swift
@@ -90,7 +90,7 @@ extension LoginFeature {
       
       switch info.provider {
       case .kakao:
-        let login = try await authClient.requestKakaoLogin(.init(idToken: info.authorization, nonce: UUID().uuidString))
+        let login = try await authClient.requestKakaoLogin(.init(idToken: info.idToken, nonce: info.nonce ?? ""))
         
         print(login)
       case .apple:


### PR DESCRIPTION
##  작업 내용

- 카카오 로그인 시 nonce 값 파라미터로 추가하여 request 하도록 수정
- Kakao sdk에서 호출하는 API에 nonce를 보내주고 해당 값을 다시 우리 쪽 API 콜 시 넣어줘야 한다.
- OpenID Connect 형식으로 로그인 하는 경우 카카오에서 idToken이라는 값을 준다. 요청시 전달된 nonce 값이 id 토큰에 포함되어야 한다.

[보안을 위한 파라미터](https://developers.kakao.com/docs/latest/ko/kakaologin/common#policy-parameter-for-security)

## 관련 이슈

- Resolved: #45 
