### PR TITLE
[BUG] iOS 18 미만에서 홈 배너 간헐적 미노출 이슈

### DIFF
--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kimkyuchul/FSPagerView-SPM",
       "state" : {
-        "revision" : "cb5a3df8e574cbef37db6823e01b7c4a6eed8258",
-        "version" : "1.3.0"
+        "revision" : "dab8d2e8b343bd65b33301582ad6c4d189f3e93b",
+        "version" : "1.3.5"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -33,6 +33,6 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", exact: "1.11.0"),
         .package(url: "https://github.com/kakao/kakao-ios-sdk", exact: "2.22.0"),
         .package(url: "https://github.com/WenchaoD/FSCalendar.git", from: "2.8.4"),
-        .package(url: "https://github.com/kimkyuchul/FSPagerView-SPM", from: "1.3.0")
+        .package(url: "https://github.com/kimkyuchul/FSPagerView-SPM", from: "1.3.5")
     ]
 )


### PR DESCRIPTION
- FSPagerView SPM의 버전 업데이트 
- collectionView.dataSource가 willMove 메서드에서 window가 사라질 시 nil이 되도록 구현되어있어 발생한 것 같음 -> deinit 시 delegate가 nil 처리 하도록 해결 

##  작업 내용

## 관련 이슈

- Resolved: #169 
