### PR TITLE
[1.0.9][BUG] 링크 요약 시 폴더 선택 과정에서는 썸네일이 로드되지 않는 이슈 

### DIFF
--- a/Projects/Core/Services/Sources/Network/LinkAPI/Response/LinkSummaryResponse.swift
+++ b/Projects/Core/Services/Sources/Network/LinkAPI/Response/LinkSummaryResponse.swift
@@ -17,6 +17,7 @@ struct LinkSummaryResponse: Decodable {
   let keywords: [String]
   let folders: [String]
   let platformImage: String
+  let thumbnailImage: String?
   let recommendFolder: String
   let recommendFolders: [String]
   let date: String
@@ -26,7 +27,7 @@ extension LinkSummaryResponse {
   public func toDomain() -> Feed {
     return Feed(
       feedId: feedId,
-      thumbnailImage: "",
+      thumbnailImage: thumbnailImage ?? "",
       platformImage: platformImage,
       title: subject,
       date: date.replacingOccurrences(of: "-", with: "."),


### PR DESCRIPTION
##  작업 내용

- 링크 요약 시 폴더 선택 과정에서는 썸네일이 로드되지 않는 이슈 

## 관련 이슈

- Resolved: #174 
