### PR TITLE
[1.1.0][CHORE] AppTrackingTransparency 심사 이슈 수정

### DIFF
--- a/Projects/App/Sources/AppDelegateFeature.swift
+++ b/Projects/App/Sources/AppDelegateFeature.swift
@@ -42,7 +42,6 @@ struct AppDelegateFeature {
   @Dependency(\.userDefaultsClient) private var userDefault
   @Dependency(\.socialLogin) private var socialLogin
   @Dependency(\.userNotificationClient) private var userNotificationClient
-  @Dependency(ATTrackingManagerClient.self) private var attrackingManagerClient
   @Dependency(GoogleMobileAdsClient.self) private var googleMobileAdsClient
   
   var body: some ReducerOf<Self> {
@@ -85,10 +84,7 @@ struct AppDelegateFeature {
         }
         
       case .setUpGoogleAds:
-        return .run { send in
-          await attrackingManagerClient.requestTrackingAuthorization()
-          await googleMobileAdsClient.start()
-        }
+        return .run { send in await googleMobileAdsClient.start() }
         
       case .setUserNotificationCenterDelegate:
         return .run { send in

--- a/Projects/Core/Services/Sources/ATTrackingManager/ATTrackingManagerClient.swift
+++ b/Projects/Core/Services/Sources/ATTrackingManager/ATTrackingManagerClient.swift
@@ -14,6 +14,7 @@ import DependenciesMacros
 
 @DependencyClient
 public struct ATTrackingManagerClient {
+  public var trackingAuthorizationStatus: @Sendable () -> ATTrackingManager.AuthorizationStatus = { .notDetermined }
   public var requestTrackingAuthorization: @Sendable () async -> Void
 }
 
@@ -22,6 +23,9 @@ extension ATTrackingManagerClient: DependencyKey {
   private static func live() -> ATTrackingManagerClient {
     
     return ATTrackingManagerClient(
+      trackingAuthorizationStatus: { @MainActor in
+        return ATTrackingManager.trackingAuthorizationStatus
+      },
       requestTrackingAuthorization: { @MainActor in
         return await withCheckedContinuation { continuation in
           ATTrackingManager.requestTrackingAuthorization { _ in

--- a/Projects/Core/Services/Sources/ATTrackingManager/ATTrackingManagerClient.swift
+++ b/Projects/Core/Services/Sources/ATTrackingManager/ATTrackingManagerClient.swift
@@ -23,7 +23,7 @@ extension ATTrackingManagerClient: DependencyKey {
   private static func live() -> ATTrackingManagerClient {
     
     return ATTrackingManagerClient(
-      trackingAuthorizationStatus: { @MainActor in
+      trackingAuthorizationStatus: {
         return ATTrackingManager.trackingAuthorizationStatus
       },
       requestTrackingAuthorization: { @MainActor in

--- a/Projects/Feature/Scene/Root/RootFeature.swift
+++ b/Projects/Feature/Scene/Root/RootFeature.swift
@@ -32,7 +32,13 @@ public struct RootFeature {
     case onAppear
     case onOpenURL(URL)
     
+    // MARK: App LifeCycle
+    case background
+    case inactive
+    case active
+    
     // MARK: Inner Business Action
+    case requestATTrackingAuthorization
     
     // MARK: Inner SetState Action
     case changeScreen(State)
@@ -45,6 +51,7 @@ public struct RootFeature {
     case mainTab(BKTabFeature.Action)
   }
   
+  @Dependency(ATTrackingManagerClient.self) private var attrackingManagerClient
   @Dependency(\.socialLogin) private var socialLogin
   
   public var body: some ReducerOf<Self> {
@@ -57,6 +64,24 @@ public struct RootFeature {
         socialLogin.handleKakaoUrl(url)
         return .none
         
+      case .background:
+        return .none
+        
+      case .inactive:
+        return .none
+        
+      case .active:
+        return .run { send in
+          await send(.requestATTrackingAuthorization)
+        }
+        
+      case .requestATTrackingAuthorization:
+        return .run { send in
+          if attrackingManagerClient.trackingAuthorizationStatus() == .notDetermined {
+            await attrackingManagerClient.requestTrackingAuthorization()
+          }
+        }
+
       case let .changeScreen(newState):
         state = newState
         return .none

--- a/Projects/Feature/Scene/Root/RootView.swift
+++ b/Projects/Feature/Scene/Root/RootView.swift
@@ -12,6 +12,7 @@ import ComposableArchitecture
 
 public struct RootView: View {
   private let store: StoreOf<RootFeature>
+  @Environment(\.scenePhase) private var scenePhase
   
   public init(store: StoreOf<RootFeature>) {
     self.store = store
@@ -49,12 +50,20 @@ public struct RootView: View {
       .onReceive(NotificationCenter.default.publisher(for: .tokenExpired)) { _ in
         store.send(.changeScreen(.login()))
       }
-      .animation(.easeInOut(duration: 0.5), value: store.state)
-      .task {
-        await store
-          .send(.onAppear)
-          .finish()
+      .onChange(of: scenePhase) { newValue in
+        switch newValue {
+        case .background:
+          store.send(.background)
+        case .inactive:
+          store.send(.inactive)
+        case .active:
+          store.send(.active)
+        @unknown default:
+          assertionFailure("Unknown scene phase")
+        }
       }
+      .animation(.easeInOut(duration: 0.5), value: store.state)
+      .task { await store.send(.onAppear).finish() }
     }
   }
 }

--- a/Projects/Feature/Scene/TabBar/BKTabFeature.swift
+++ b/Projects/Feature/Scene/TabBar/BKTabFeature.swift
@@ -10,6 +10,7 @@ import Foundation
 
 import Analytics
 import Models
+import Services
 import CommonFeature
 
 import ComposableArchitecture
@@ -51,6 +52,7 @@ public struct BKTabFeature {
     case feedDetailWillDisappear(Feed)
     
     // MARK: Inner Business Action
+    case requestATTrackingAythorization
     case handleUnsavedSummary
     case fetchLinkProcessing(Int)
     
@@ -65,7 +67,6 @@ public struct BKTabFeature {
     
     case delegate(Delegate)
     
-    
     case path(StackAction<Path.State, Path.Action>)
     case storageBox(StorageBoxFeature.Action)
     case home(HomeFeature.Action)
@@ -77,8 +78,9 @@ public struct BKTabFeature {
     case unsavedSummaryAlertPresented(Int)
   }
   
-  @Dependency(\.linkClient) private var linkClient
+  @Dependency(ATTrackingManagerClient.self) private var attrackingManagerClient
   @Dependency(AnalyticsClient.self) private var analyticsClient
+  @Dependency(\.linkClient) private var linkClient
   @Dependency(\.alertClient) private var alertClient
   @Dependency(\.userDefaultsClient) private var userDefaultsClient
   
@@ -98,7 +100,10 @@ public struct BKTabFeature {
         return .none
         
       case .onViewDidLoad:
-        return .send(.handleUnsavedSummary)
+        return .run { send in
+            await send(.requestATTrackingAythorization)
+            await send(.handleUnsavedSummary)
+        }
                 
         /// - 탭바 중앙 CIrcle 버튼 눌렀을 때
       case .roundedTabIconTapped:
@@ -106,6 +111,11 @@ public struct BKTabFeature {
         
         state.path.append(.SaveLink(SaveLinkFeature.State()))
         return .none
+        
+      case .requestATTrackingAythorization:
+        return .run { send in
+          await attrackingManagerClient.requestTrackingAuthorization()
+        }
                 
       case .handleUnsavedSummary:
         guard userDefaultsClient.integer(.latestUnsavedSummaryFeedId, -1) > 0 else {

--- a/Projects/Feature/Scene/TabBar/BKTabFeature.swift
+++ b/Projects/Feature/Scene/TabBar/BKTabFeature.swift
@@ -10,7 +10,6 @@ import Foundation
 
 import Analytics
 import Models
-import Services
 import CommonFeature
 
 import ComposableArchitecture
@@ -52,7 +51,6 @@ public struct BKTabFeature {
     case feedDetailWillDisappear(Feed)
     
     // MARK: Inner Business Action
-    case requestATTrackingAythorization
     case handleUnsavedSummary
     case fetchLinkProcessing(Int)
     
@@ -78,7 +76,6 @@ public struct BKTabFeature {
     case unsavedSummaryAlertPresented(Int)
   }
   
-  @Dependency(ATTrackingManagerClient.self) private var attrackingManagerClient
   @Dependency(AnalyticsClient.self) private var analyticsClient
   @Dependency(\.linkClient) private var linkClient
   @Dependency(\.alertClient) private var alertClient
@@ -100,10 +97,7 @@ public struct BKTabFeature {
         return .none
         
       case .onViewDidLoad:
-        return .run { send in
-            await send(.requestATTrackingAythorization)
-            await send(.handleUnsavedSummary)
-        }
+        return .run { send in await send(.handleUnsavedSummary) }
                 
         /// - 탭바 중앙 CIrcle 버튼 눌렀을 때
       case .roundedTabIconTapped:
@@ -111,12 +105,7 @@ public struct BKTabFeature {
         
         state.path.append(.SaveLink(SaveLinkFeature.State()))
         return .none
-        
-      case .requestATTrackingAythorization:
-        return .run { send in
-          await attrackingManagerClient.requestTrackingAuthorization()
-        }
-                
+                        
       case .handleUnsavedSummary:
         guard userDefaultsClient.integer(.latestUnsavedSummaryFeedId, -1) > 0 else {
           return .none


### PR DESCRIPTION
##  작업 내용

- didFinishLaunchingWithOptions에서 ATTrackingRequest 호출 시 iOS 18.3에서 ATTracking Alert 노출되지 않는 이슈
- scenePhase에서 라이프사이클 접근하여 active 상태(Scene이 foreground에 있고 interactive(상호작용 할 수 있는) 상태)에서 ATTrackingRequest 호출하도록 수정

## 관련 이슈

- Resolved: #180 
