### PR TITLE
[1.1.1][BUG] 최초 회원가입 시 온보딩 피드 존재로 온보딩 뷰로 진입하지 않는 이슈 

### DIFF
--- a/Projects/Feature/Scene/Auth/Login/LoginFeature.swift
+++ b/Projects/Feature/Scene/Auth/Login/LoginFeature.swift
@@ -158,7 +158,7 @@ public struct LoginFeature {
             await send(.setLoading(false))
             try? await Task.sleep(for: .seconds(0.2))
             
-            if folderList.isEmpty {
+            if isCheckOnboarding(folderList) {
               await send(.delegate(.moveToOnboarding))
             } else {
               await send(.delegate(.moveToMainTab))
@@ -239,6 +239,16 @@ public struct LoginFeature {
         return .none
       }
     }
+  }
+}
+
+// MARK: Private
+
+extension LoginFeature {
+  func isCheckOnboarding(_ folderList: [Folder]) -> Bool {
+    guard !folderList.isEmpty else { return true }
+    
+    return folderList.count == 1 && folderList.first?.name == "블링크 소개"
   }
 }
 


### PR DESCRIPTION
##  작업 내용

- 폴더 리스트가 비워져 있거나 or 블링크 소개 라는 폴더만 1개 존재 시 온보딩 이동

## 관련 이슈

- Resolved: #182 
