### PR TITLE
[1.1.3][BUG] 요약 중인 리스트 > 요약 확인페이지 갔다가 백버튼 시 홈으로 가는 이슈

### DIFF
--- a/Projects/Feature/Scene/TabBar/BKTabFeature.swift
+++ b/Projects/Feature/Scene/TabBar/BKTabFeature.swift
@@ -257,7 +257,7 @@ public struct BKTabFeature {
         
         /// - 요약 완료 화면 -> `확인` 버튼 누르지 않고 `뒤로가기` 버튼 눌렀을 때
       case .path(.element(id: _, action: .Link(.delegate(.summaryCompletedCloseButtonTapped)))):
-        state.path.removeAll()
+        state.path.removeLast()
         return .none
         
         /// - 링크 요약 이후 저장 화면 -> `뒤로가기` 버튼 눌렀을 때


### PR DESCRIPTION
##  작업 내용

- 요약 중인 리스트 > 요약 확인페이지 갔다가 백버튼 시 홈으로 가는 이슈

## 관련 이슈

- Resolved: #191
