### PR TITLE
[1.1.3][FEATURE] 푸시 알림 클릭시 요약 링크 리스트 페이지로 이동

### DIFF
--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -20,9 +20,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
       AppDelegateFeature()
     }
   )
-  
-  @Dependency(\.userNotificationClient) private var userNotificationClient
-  
+
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?

--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -9,26 +9,41 @@
 import SwiftUI
 
 import Feature
+import Services
 
 import ComposableArchitecture
 
-final class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+final class AppDelegate: UIResponder, UIApplicationDelegate {
   let store = StoreOf<AppDelegateFeature>.init(
-      initialState: .init(),
-      reducer: {
-        AppDelegateFeature()
-      }
-    )
+    initialState: .init(),
+    reducer: {
+      AppDelegateFeature()
+    }
+  )
+  
+  @Dependency(\.userNotificationClient) private var userNotificationClient
   
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    UNUserNotificationCenter.current().delegate = self
     store.send(.didFinishLaunching)
     return true
   }
   
   func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     store.send(.didRegisterForRemoteNotificationsWithDeviceToken(deviceToken: deviceToken))
+  }
+}
+
+extension AppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
+  func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+    let userInfo = response.notification.request.content.userInfo
+    let notificationId = userInfo["id"] as? String ?? UUID().uuidString
+    let payload = NotificationPayload(id: notificationId, userInfo: userInfo)
+    
+    store.send(.didReceiveRemoteNotification(payload))
+    completionHandler()
   }
 }

--- a/Projects/App/Sources/AppDelegateFeature.swift
+++ b/Projects/App/Sources/AppDelegateFeature.swift
@@ -23,6 +23,7 @@ struct AppDelegateFeature {
   enum Action: Sendable {
     case didFinishLaunching
     case didRegisterForRemoteNotificationsWithDeviceToken(deviceToken: Data)
+    case didReceiveRemoteNotification(NotificationPayload)
     
     case initKakaoSDK
     case setUpNotificationCenter
@@ -57,6 +58,11 @@ struct AppDelegateFeature {
           await send(.setUpFirebase)
           /// Google Ads 설정
           await send(.setUpGoogleAds)
+        }
+        
+      case let .didReceiveRemoteNotification(payload):
+        return .run { @MainActor [payload] _ in
+          userNotificationClient.notificationReceiveSend(payload)
         }
         
       case let .didRegisterForRemoteNotificationsWithDeviceToken(deviceToken):
@@ -110,9 +116,16 @@ struct AppDelegateFeature {
         // foreground에서 노티 수신 방법 설정
         return .run { send in completionHandler([.banner, .badge, .sound]) }
         
-      case let .setUserNotifications(.didReceiveResponse(_, completionHandler)):
+      case let .setUserNotifications(.didReceiveResponse(response, completionHandler)):
+        let userInfo = response.notification.request.content.userInfo
+        let notificationId = userInfo["id"] as? String ?? UUID().uuidString
+        let payload = NotificationPayload(id: notificationId, userInfo: userInfo)
+        
         //  백그라운드에서 푸시 알림을 탭했을 때 실행
-        return .run { @MainActor _ in completionHandler() }
+        return .run { @MainActor [payload] _ in
+          userNotificationClient.notificationReceiveSend(payload)
+          completionHandler()
+        }
         
       case .setFirebaseConfigure:
         FirebaseApp.configure()

--- a/Projects/Core/Services/Sources/UserNotification/UserNotificationClient.swift
+++ b/Projects/Core/Services/Sources/UserNotification/UserNotificationClient.swift
@@ -16,6 +16,8 @@ public struct UserNotificationClient {
   public var requestAuthorization: @Sendable () async throws -> Void
   public var getAuthorizationStatus: @Sendable () async -> UNAuthorizationStatus = { .notDetermined }
   public var registerForRemoteNotifications: @Sendable () async -> Void
+  public var notificationReceiveStream: @Sendable () -> AsyncStream<NotificationPayload>
+  public var notificationReceiveSend: @Sendable (NotificationPayload) -> Void
   
   
   public enum DelegateEvent: Sendable {
@@ -26,6 +28,8 @@ public struct UserNotificationClient {
 
 extension UserNotificationClient: DependencyKey {
   public static var liveValue: UserNotificationClient {
+    let notificationReceiveStream = AsyncStream<NotificationPayload>.makeStream()
+    
     return Self(
       delegate: {
         AsyncStream { continuation in
@@ -44,6 +48,12 @@ extension UserNotificationClient: DependencyKey {
       },
       registerForRemoteNotifications: { @MainActor in
         UIApplication.shared.registerForRemoteNotifications()
+      },
+      notificationReceiveStream: {
+        notificationReceiveStream.stream
+      },
+      notificationReceiveSend: { payload in
+        notificationReceiveStream.continuation.yield(payload)
       }
     )
   }
@@ -80,4 +90,21 @@ extension UserNotificationClient {
       )
     }
   }
+}
+
+public struct NotificationPayload: Equatable, @unchecked Sendable {
+  public let id: String
+  public let userInfo: [AnyHashable: Any]
+  
+  public init(
+    id: String,
+    userInfo: [AnyHashable : Any]
+  ) {
+    self.id = id
+    self.userInfo = userInfo
+  }
+    
+  public static func == (lhs: NotificationPayload, rhs: NotificationPayload) -> Bool {
+        lhs.id == rhs.id
+    }
 }

--- a/Projects/Feature/Scene/TabBar/BKTabFeature.swift
+++ b/Projects/Feature/Scene/TabBar/BKTabFeature.swift
@@ -49,6 +49,7 @@ public struct BKTabFeature {
     case onViewDidLoad
     case roundedTabIconTapped
     case feedDetailWillDisappear(Feed)
+    case backgroundNotificationReceived
     
     // MARK: Inner Business Action
     case handleUnsavedSummary
@@ -70,6 +71,7 @@ public struct BKTabFeature {
     case home(HomeFeature.Action)
     
     // MARK: Navigation Action
+    case routeSummaryStatus
     case routeSummaryCompleted(Int)
     
     // MARK: Present Action
@@ -80,6 +82,7 @@ public struct BKTabFeature {
   @Dependency(\.linkClient) private var linkClient
   @Dependency(\.alertClient) private var alertClient
   @Dependency(\.userDefaultsClient) private var userDefaultsClient
+  @Dependency(\.userNotificationClient) private var userNotificationClient
   
   public var body: some ReducerOf<Self> {
     Scope(state: \.storageBox, action: \.storageBox) { StorageBoxFeature() }
@@ -97,14 +100,25 @@ public struct BKTabFeature {
         return .none
         
       case .onViewDidLoad:
-        return .run { send in await send(.handleUnsavedSummary) }
-                
+        return .run { send in
+          await send(.backgroundNotificationReceived)
+          await send(.handleUnsavedSummary)
+        }
+        
         /// - 탭바 중앙 CIrcle 버튼 눌렀을 때
       case .roundedTabIconTapped:
         roundedTabIconTappedLog()
         
         state.path.append(.SaveLink(SaveLinkFeature.State()))
         return .none
+        
+      case .backgroundNotificationReceived:
+        return .run { send in
+          for await payload in userNotificationClient.notificationReceiveStream() {
+            try? await Task.sleep(for: .seconds(0.5))
+            await send(.routeSummaryStatus)
+          }
+        }
                         
       case .handleUnsavedSummary:
         guard userDefaultsClient.integer(.latestUnsavedSummaryFeedId, -1) > 0 else {
@@ -264,6 +278,10 @@ public struct BKTabFeature {
       case .path(.element(id: _, action: .Link(.delegate(.summarySaveCloseButtonTapped)))):
         state.path.removeAll()
         return .send(.home(.summarySaveDisappear))
+        
+      case .routeSummaryStatus:
+        state.path.append(.SummaryStatus(SummaryStatusFeature.State()))
+        return .none
                 
       case let .routeSummaryCompleted(feedId):
         state.path.append(.Link(LinkFeature.State(linkType: .summaryCompleted, feedId: feedId)))


### PR DESCRIPTION
##  작업 내용

- 푸시 알림 클릭시 요약 링크 리스트 페이지로 이동 (포그라운드, 백그라운드, 앱 종료 시)

## 관련 이슈

- Resolved: #196